### PR TITLE
this needs to be https.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -11,7 +11,7 @@ function Strategy(options, verify) {
 		options = {};
 	}
 
-	options.gitlabURL = options.gitlabURL || 'http://gitlab.com';
+	options.gitlabURL = options.gitlabURL || 'https://gitlab.com';
 	
   	if (!options.gitlabURL) { throw new TypeError('OAuth2Strategy requires a gitlabURL option'); }
   	


### PR DESCRIPTION
Gitlab will 301 redirect the auth flow if you're not https.
This is not handled in the userProfile method, nor will your receive an access token from the OAuth2 base strategy.
You can work around this issue by supplying the proper URL in the options but the default won't work
